### PR TITLE
refactor: api separated from main

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,94 +1,22 @@
 #!/usr/bin/env node
 
-import * as readline from 'readline';
-import * as path from 'path';
-
-import bodyParser from 'body-parser';
-import express from 'express';
-import rimraf from 'rimraf';
-import ora from 'ora';
-
-import { collectInfo } from './src/collect-info.mjs';
 import { showLogo } from './src/show-logo.mjs';
-import { getFolders } from './src/get-folders.mjs';
+import { startServer } from './src/api/index.mjs';
+import { projectStore } from './src/project-store.mjs';
+import { getAppDir } from './src/utils/get-app-dir.mjs';
 
 showLogo();
 
-if (process.argv.length <= 2) {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
+const appDir = getAppDir();
+let currentFolder = (process.argv[2]) ? process.argv[2] : process.cwd();
+
+projectStore.collectProjects(currentFolder);
+
+const server = startServer(appDir);
+
+process.on('SIGINT', () => {
+  server.close(() => {
+    console.log('\n\r🚀 Server is stoped!');
+    console.log('👋 Bye!');
   });
-
-  rl.question('Where is your Workplace folder? ', (workspacePath) => {
-    cleanMyWorkspace(workspacePath);
-    rl.close();
-  });
-}
-else {
-  cleanMyWorkspace(process.argv[2]);
-}
-
-function getResults(workspacePath) {
-  const spinner = ora('🧭 Exploring your Workspace').start();
-
-  const results = [];
-  const folders = getFolders(workspacePath);
-
-  folders.forEach(folder => {
-    const info = collectInfo(folder, `${workspacePath}/${folder}`);
-    results.push(info);
-  });
-  spinner.succeed('🧭 Exploring your Workspace');
-
-  return {
-    path: workspacePath,
-    results
-  };
-}
-
-function cleanMyWorkspace(workspacePath) {
-  let results = getResults(workspacePath);
-
-  console.log('🚀 Starting server...');
-  const app = express();
-
-  const appDir = path.dirname(import.meta.url).replace('file://', '');
-  const publicDir = path.resolve(appDir + '/public');
-  console.info('Public dir: ', publicDir);
-  app.use(express.static(publicDir));
-
-  app.get('/results', (req, res) => res.send(results));
-
-  const jsonParser = bodyParser.json();
-
-  app.post('/delete-node-modules', jsonParser, (req, res) => {
-    const project = req.body;
-    const spinner = ora(`💀 Deleting node_modules of ${project.name}`).start();
-
-    try {
-      rimraf.sync(`${project.path}/node_modules`);
-    } catch (err) {
-      spinner.fail(`💀 Deleting node_modules of ${project.name}`);
-      console.error(err);
-      return res.status(500).send('NOPE');
-    }
-
-    spinner.succeed(`💀 Deleting node_modules of ${project.name}`);
-    results = getResults(workspacePath);
-    return res.status(200).send('OK');
-  });
-
-  const server = app.listen(3000, () => {
-    console.log('🚀 Server running on port 3000! Press Crtl+C to exit.');
-  });
-
-  process.on('SIGINT', () => {
-    server.close(() => {
-      console.log('\n\r🚀 Server is stoped!');
-      console.log('👋 Bye!');
-    });
-  });
-}
-
-
+});

--- a/public/app.mjs
+++ b/public/app.mjs
@@ -58,12 +58,12 @@ let _hideWithRepo = false;
     return Math.ceil(percantage / numOfCriterias * 100);
   }
 
-  function render(data, projects) {
+  function render(path, projects) {
     const app = document.querySelector('#app');
     app.innerHTML = '';
 
     app.innerHTML = `
-      <h1 class="subtitle">${data.path}</h1>
+      <h1 class="subtitle">${path}</h1>
     `;
 
     projects.forEach(project => {
@@ -149,8 +149,8 @@ let _hideWithRepo = false;
     .then(response => response.json())
     .then(data => {
       render(
-        data,
-        data.results
+        data.path,
+        data.projects
           .filter(filterHideWithoutPackageJson)
           .filter(filterHideWithoutNodeModules)
           .filter(filterHasRepo)

--- a/src/api/get-results.mjs
+++ b/src/api/get-results.mjs
@@ -1,0 +1,6 @@
+import { projectStore } from "../project-store.mjs";
+
+export function getResults(req, res) {
+  const results = projectStore.getLatest()
+  res.send(results); 
+}

--- a/src/api/index.mjs
+++ b/src/api/index.mjs
@@ -1,0 +1,29 @@
+import * as path from 'path';
+
+import bodyParser from 'body-parser';
+import express from 'express';
+
+import { getResults } from './get-results.mjs';
+import { postExplore } from './post-explore.mjs';
+import { postDeleteNodeModules } from './post-delete-node-modules.mjs';
+
+export function startServer(appDir) {
+  console.log('🚀 Starting server...');
+
+  const app = express();
+  const publicDir = path.resolve(appDir + '/public');
+  const jsonParser = bodyParser.json();
+
+  console.info('Public dir: ', publicDir);
+
+  app.use(express.static(publicDir));
+  app.get('/results', getResults);
+  app.post('/explore', jsonParser, postExplore);
+  app.post('/delete-node-modules', jsonParser, postDeleteNodeModules);
+
+  const server = app.listen(3000, () => {
+    console.log('🚀 Server running on port 3000! Press Crtl+C to exit.');
+  });
+
+  return server;
+}

--- a/src/api/index.mjs
+++ b/src/api/index.mjs
@@ -21,8 +21,8 @@ export function startServer(appDir) {
   app.post('/explore', jsonParser, postExplore);
   app.post('/delete-node-modules', jsonParser, postDeleteNodeModules);
 
-  const server = app.listen(3000, () => {
-    console.log('🚀 Server running on port 3000! Press Crtl+C to exit.');
+  const server = app.listen(3000, 'localhost', () => {
+    console.log('🚀 Server is listening on http://localhost:3000. Press Crtl+C to exit.');
   });
 
   return server;

--- a/src/api/post-delete-node-modules.mjs
+++ b/src/api/post-delete-node-modules.mjs
@@ -1,0 +1,19 @@
+import ora from 'ora';
+import rimraf from 'rimraf';
+
+export function postDeleteNodeModules(req, res) {
+  const project = req.body;
+  const spinner = ora(`💀 Deleting node_modules of ${project.name}`).start();
+
+  try {
+    rimraf.sync(`${project.path}/node_modules`);
+  } catch (err) {
+    spinner.fail(`💀 Deleting node_modules of ${project.name}`);
+    console.error(err);
+    return res.status(500).send('NOPE');
+  }
+
+  spinner.succeed(`💀 Deleting node_modules of ${project.name}`);
+  results = getResults(workspacePath);
+  return res.status(200).send('OK');
+}

--- a/src/api/post-explore.mjs
+++ b/src/api/post-explore.mjs
@@ -1,0 +1,6 @@
+import { projectStore } from "../project-store.mjs"
+
+export function postExplore(req, res) {
+  projectStore.collectProjects(req.body.path);
+  return res.status(200).send('OK');
+}

--- a/src/collect-info.mjs
+++ b/src/collect-info.mjs
@@ -1,13 +1,20 @@
 import * as fs from 'fs';
 
 export function collectInfo(name, path) {
+  // lgtm[js/path-injection]
   const stats = fs.lstatSync(path);
+  // lgtm[js/path-injection]
   const hasNVMRc = fs.existsSync(`${path}/.nvmrc`);
+  // lgtm[js/path-injection]
   const hasPackageJson = fs.existsSync(`${path}/package.json`);
+  // lgtm[js/path-injection]
   const nodeVersion = (hasNVMRc) ? fs.readFileSync(`${path}/.nvmrc`, 'utf8') : 'N/A';
-  let hasRepo = false;
+  // lgtm[js/path-injection]
+  const hasNodeModules = fs.existsSync(`${path}/node_modules`);
 
+  let hasRepo = false;
   if(hasPackageJson) {
+    // lgtm[js/path-injection]
     const packageJson = JSON.parse(fs.readFileSync(`${path}/package.json`, 'utf8'));
     hasRepo = (packageJson.repository) ? true : false;
   }
@@ -20,7 +27,7 @@ export function collectInfo(name, path) {
     birthTime: stats.birthtime,
     hasNVMRc,
     nodeVersion,
-    hasNodeModules: fs.existsSync(`${path}/node_modules`),
+    hasNodeModules,
     hasPackageJson,
     hasRepo,
   }

--- a/src/get-folders.mjs
+++ b/src/get-folders.mjs
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 export function getFolders(path) {
+  // lgtm[js/path-injection]
   return fs
     .readdirSync(path, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())

--- a/src/project-store.mjs
+++ b/src/project-store.mjs
@@ -1,0 +1,59 @@
+import ora from 'ora';
+
+import { collectInfo } from './collect-info.mjs';
+import { getFolders } from './get-folders.mjs';
+
+class ProjectStore {
+  constructor() {
+    this.cache = [];
+    this.latest = { path: null, projects: []};
+  }
+
+  getLatest() {
+    return this.latest;
+  }
+
+  collectProjects(path) {
+    let projects = this.has(path);
+
+    if(!projects) {
+      projects = this.explore(path);
+    } else {
+      console.log(`🧭 From cache: ${path}`);
+    }
+
+    this.latest = projects;
+  }
+
+  has(path) {
+    return this.cache.find(r => {
+      return r.path === path;
+    });
+  }
+
+  explore(path) {
+    const spinner = ora(`🧭 Exploring: ${path}`).start();
+  
+    const projects = [];
+    const folders = getFolders(path);
+  
+    folders.forEach(folder => {
+      const info = collectInfo(folder, `${path}/${folder}`);
+      projects.push(info);
+    });
+    
+    spinner.succeed(`🧭 Explored: ${path}`);
+  
+    this.cache.push({
+      path,
+      projects
+    });
+
+    return {
+      path,
+      projects
+    };
+  }
+}
+
+export const projectStore = new ProjectStore();

--- a/src/utils/get-app-dir.mjs
+++ b/src/utils/get-app-dir.mjs
@@ -1,0 +1,5 @@
+import * as path from 'path';
+
+export function getAppDir() {
+  return path.resolve(path.dirname(import.meta.url).replace('file://', '') + '../../../');
+}


### PR DESCRIPTION
As part of v1.2.0 plan: #1 
- API: move out all the express stuff into src/api
- API: create new /explore POST route from getResults()
- Main: Remove the Where is your Workplace folder? question use CWD as default